### PR TITLE
feat: Configure TypeScript for ES2023 with strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build/
 *.js
 *.js.map
 *.d.ts
+*.d.ts.map
+.tsbuildinfo
+.tsbuildinfo.build
 
 # Keep TypeScript source files
 !src/**/*.ts

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "llm-code-analyzer": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "dev": "ts-node src/index.ts",
     "test": "jest",
     "lint": "eslint src --ext .ts",

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -1,4 +1,4 @@
-import { AnalysisResult, AnalyzerConfig } from '@/types';
+import type { AnalysisResult, AnalyzerConfig } from '@/types';
 import { LLMProvider } from '@/providers';
 import { RuleEngine } from '@/rules';
 import { FileScanner } from '@/utils/scanner';

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="node" />
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      NODE_ENV: 'development' | 'production' | 'test';
+      OPENAI_API_KEY?: string;
+      // Add other environment variables as needed
+    }
+  }
+}
+
+// Ensure this is treated as a module
+export {};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": false,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "tsBuildInfoFile": ".tsbuildinfo.build"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    ".next",
+    "coverage",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx", 
+    "**/*.test.tsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,42 +1,100 @@
 {
   "compilerOptions": {
+    /* Language and Environment */
     "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "lib": ["ES2023"],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
     
+    /* Strict Type-Checking Options */
     "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true,
+    "alwaysStrict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true,
     
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    
-    "incremental": true,
-    "tsBuildInfoFile": ".tsbuildinfo",
-    
+    /* Module Resolution Options */
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@/lib/*": ["./src/lib/*"],
       "@/types/*": ["./src/types/*"],
       "@/analyzers/*": ["./src/analyzers/*"],
-      "@/providers/*": ["./src/providers/*"]
+      "@/providers/*": ["./src/providers/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/hooks/*": ["./src/hooks/*"],
+      "@/utils/*": ["./src/utils/*"],
+      "@/config/*": ["./src/config/*"],
+      "@/app/*": ["./src/app/*"]
     },
-    
-    "useUnknownInCatchVariables": true,
+    "resolveJsonModule": true,
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+    
+    /* Emit Options */
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "removeComments": true,
+    "importHelpers": true,
+    "downlevelIteration": true,
+    "newLine": "lf",
+    
+    /* Interop Constraints */
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    
+    /* Type Checking Performance */
+    "skipLibCheck": true,
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo",
+    
+    /* Advanced Options */
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "preserveConstEnums": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
-  "exclude": ["node_modules", "dist", ".next", "coverage"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.js",
+    "src/**/*.jsx",
+    "src/**/*.json",
+    "next-env.d.ts",
+    "**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    ".next",
+    "coverage",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    ".tsbuildinfo",
+    "scripts",
+    "jest.config.*",
+    "*.config.js"
+  ],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Configured TypeScript for modern ES2023 features with comprehensive strict mode settings
- Set up build pipeline with separate compilation configuration
- Added path aliases for cleaner imports

## Changes
- **Updated tsconfig.json** with ES2023 target and all strict mode options enabled
- **Created tsconfig.build.json** for compilation with proper emit settings
- **Added path aliases** for @/components, @/hooks, @/utils, @/config, and @/app
- **Configured incremental builds** for better performance
- **Added global type declarations** file for environment variables
- **Updated .gitignore** to exclude TypeScript build artifacts
- **Fixed type imports** to use 'import type' syntax for verbatimModuleSyntax compliance

## Testing
- [x] TypeScript compiles without errors using `npx tsc --noEmit`
- [x] Build script updated to use tsconfig.build.json
- [x] Path aliases configured and ready for use

## Related Issues
Closes #16
Part of #1

🤖 Generated with [Claude Code](https://claude.ai/code)